### PR TITLE
readme: link to sponsorship

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ All the scripts in my Talon user directory.
 
 In constant development. Things will break!
 
+> **Note**
+> If you find the scripts in this repository helpful, [consider sponsoring](https://github.com/sponsors/AndreasArvidsson)!
+
 ## Interesting features
 
 This is a list of features that I have implemented that I think is of more interest to other Talon users. Things I have already upstreamed to [knausj](https://github.com/knausj85/knausj_talon) are omitted. Since I don't actually use a fork of knausj some modifications (often different names) might be required.


### PR DESCRIPTION
In the meeting it came up that Jacob didn't know andreas was taking sponsorships; the GitHub UI sort of buries this in the sidebar, so let's make it more prevalent by putting it in the README. This means the people who just clone the repository have a chance to see it as well.