### PR TITLE
change the hotkey for rpc based on the host OS

### DIFF
--- a/plugins/clippy/clippy.py
+++ b/plugins/clippy/clippy.py
@@ -1,10 +1,13 @@
 from typing import Any, Optional
-from talon import Module, Context, actions, ui
+from talon import Module, Context, actions, app, ui
 
 from ...core.rpc_client.rpc_client import RpcClient
 from .clippy_targets import ClippyPrimitiveTarget, ClippyTarget
 
-rpc = RpcClient("Clippy", "ctrl-shift-alt-o")
+if app.platform == "mac":
+    rpc = RpcClient("Clippy", "cmd-shift-f18")
+else:
+    rpc = RpcClient("Clippy", "ctrl-shift-alt-o")
 
 mod = Module()
 


### PR DESCRIPTION
This PR changes the default `key` for the rpc client, based on the host OS.  For some reason, macOS does not like the hotkey `ctrl-shift-alt-o`, so if the code is running on a mac, we use `cmd-shift-f18` instead.  See the corresponding PR in the clippy repo here: https://github.com/AndreasArvidsson/clippy/pull/5